### PR TITLE
fix: remove trailing comma from .prettierrc (#54)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
   "semi": true,
   "singleQuote": true,
-  "tabWidth": 2,
+  "tabWidth": 2
 }


### PR DESCRIPTION
## Description
Removes an invalid trailing comma from the JSON body that causes formatting failures.
