### PR TITLE
docs: fix typo in install command in README (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A scroll-driven, cinematic web experience built with GSAP and ScrollTrigger. Des
 
 1. **Install dependencies**
    ```sh
-   npm iX
+   npm install
    ```
 2. **Start development server**
    ```sh


### PR DESCRIPTION
## Description
Corrects `npm iX` to `npm install` under setup rules.
