### PR TITLE
fix(SequenceController): use Math.floor in setProgress to avoid frame skips (#50)

### DIFF
--- a/src/utils/SequenceController.js
+++ b/src/utils/SequenceController.js
@@ -104,7 +104,11 @@ export default class SequenceController {
   /* ================= MAIN ================= */
 
   setProgress(progress) {
-    const index = Math.ceil(progress * (this.frameCount - 1));
+    // Math.floor maps progress=0 → 0 and progress=1 → frameCount-1 with
+    // monotonic step transitions. Math.ceil here jumped past frame 0 on
+    // any progress > 0 and could skip a frame at the boundary, causing
+    // the visible "jump" reported in #50.
+    const index = Math.floor(progress * (this.frameCount - 1));
 
     if (index === this.currentIndex) return;
 


### PR DESCRIPTION
Fixes #50. `setProgress` used `Math.ceil(progress * (frameCount - 1))` to pick a frame index, which:

- maps progress=0 to index 0 only at the boundary, but ANY tiny positive progress jumps to index 1, skipping frame 0
- can over-step on near-integer products (e.g. `Math.ceil(2.0001) === 3`), causing visible jumps

Switching to `Math.floor` keeps the mapping monotonic: index 0 covers the [0, 1/(N-1)) range, etc., and progress=1 maps to N-1 cleanly.

## Test plan

- [x] Module loads cleanly (`node --input-type=module -e "import(...)"`)
- [x] Boundary trace: `progress=0 → 0`, `progress=1 → frameCount-1`, `progress=0.5 → ⌊(N-1)/2⌋`