### PR TITLE
Fix README npm install typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A scroll-driven, cinematic web experience built with GSAP and ScrollTrigger. Des
 
 1. **Install dependencies**
    ```sh
-   npm iX
+   npm install
    ```
 2. **Start development server**
    ```sh


### PR DESCRIPTION
# Pull Request

## Description
- Fixes the README setup command from `npm iX` to `npm install`.
- Linked issues: Closes #53

## Checklist
- [x] Follows contribution guidelines
- [x] Passes all tests/CI
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing
- `git diff --check`
