### PR TITLE
Fix typo: npm iX → npm install in README setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A scroll-driven, cinematic web experience built with GSAP and ScrollTrigger. Des
 
 1. **Install dependencies**
    ```sh
-   npm iX
+   npm install
    ```
 2. **Start development server**
    ```sh


### PR DESCRIPTION
## Summary

Fixes #53

The setup instructions in `README.md` show `npm iX` which is an invalid npm command. It should be `npm install`.

## Root Cause

Line 16 of `README.md` contains `npm iX` instead of the valid `npm install` command. This would fail with `Unknown command: "iX"` for anyone following the setup guide.

## Fix

Replaced `npm iX` with `npm install`, the correct command for installing project dependencies.

## Changes

- `README.md`: 1 word replaced (`+1 -1` lines)

## Testing

- `npm install` is a valid npm command ✅
- "iX" no longer appears in README.md ✅
- No other text in the file was changed ✅